### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.writing.txt
+++ b/LICENSE.writing.txt
@@ -1,1 +1,1 @@
-Except where otherwise noted, this work is licensed under http://creativecommons.org/licenses/by-nd/3.0/
+Except where otherwise noted, this work is licensed under https://creativecommons.org/licenses/by-nd/3.0/

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 :spring_boot_version: 1.5.10.RELEASE
-:EnableAutoConfiguration: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/autoconfigure/EnableAutoConfiguration.html
-:SpringApplication: http://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
+:EnableAutoConfiguration: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/autoconfigure/EnableAutoConfiguration.html
+:SpringApplication: https://docs.spring.io/spring-boot/docs/{spring_boot_version}/api/org/springframework/boot/SpringApplication.html
 :toc:
 :icons: font
 :source-highlighter: prettify
@@ -21,7 +21,7 @@ Spring's Cache Abstraction, backed by Pivotal GemFire, will be used to cache the
 The Quote service is located at...
 
 ....
-http://gturnquist-quoters.cfapps.io
+https://gturnquist-quoters.cfapps.io
 ....
 
 The Quote service has the following API...
@@ -99,7 +99,7 @@ Your next step is to create a service class that queries for quotes.
 include::complete/src/main/java/hello/QuoteService.java[]
 ----
 
-The `QuoteService` uses _Spring's_ `RestTemplate` to query the Quote service's http://gturnquist-quoters.cfapps.io/api[API].
+The `QuoteService` uses _Spring's_ `RestTemplate` to query the Quote service's https://gturnquist-quoters.cfapps.io/api[API].
 The Quote service returns a JSON object, but _Spring_ uses Jackson to bind the data to a `QuoteResponse` and ultimately,
 a `Quote` object.
 
@@ -117,7 +117,7 @@ and cached previously.
 
 The `@CachePut` uses a SpEL expression ("`#result.id`") to access the result of the service method invocation
 and retrieve the ID of the `Quote` to use as the cache key. You can learn more about _Spring's Cache Abstraction_
-SpEL context http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache-spel-context[here].
+SpEL context https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#cache-spel-context[here].
 
 NOTE: You must supply the name of the cache. We named it "Quotes" for demonstration purposes, but in production,
 it is recommended to pick an appropriately descriptive name. This also means different methods can be associated

--- a/complete/src/main/java/hello/QuoteService.java
+++ b/complete/src/main/java/hello/QuoteService.java
@@ -13,8 +13,8 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class QuoteService {
 
-	protected static final String ID_BASED_QUOTE_SERVICE_URL = "http://gturnquist-quoters.cfapps.io/api/{id}";
-	protected static final String RANDOM_QUOTE_SERVICE_URL = "http://gturnquist-quoters.cfapps.io/api/random";
+	protected static final String ID_BASED_QUOTE_SERVICE_URL = "https://gturnquist-quoters.cfapps.io/api/{id}";
+	protected static final String RANDOM_QUOTE_SERVICE_URL = "https://gturnquist-quoters.cfapps.io/api/random";
 
 	private volatile boolean cacheMiss = false;
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://gturnquist-quoters.cfapps.io (404) with 1 occurrences migrated to:  
  https://gturnquist-quoters.cfapps.io ([https](https://gturnquist-quoters.cfapps.io) result 404).
* [ ] http://gturnquist-quoters.cfapps.io/api (404) with 1 occurrences migrated to:  
  https://gturnquist-quoters.cfapps.io/api ([https](https://gturnquist-quoters.cfapps.io/api) result 404).
* [ ] http://gturnquist-quoters.cfapps.io/api/ (404) with 1 occurrences migrated to:  
  https://gturnquist-quoters.cfapps.io/api/ ([https](https://gturnquist-quoters.cfapps.io/api/) result 404).
* [ ] http://gturnquist-quoters.cfapps.io/api/random (404) with 1 occurrences migrated to:  
  https://gturnquist-quoters.cfapps.io/api/random ([https](https://gturnquist-quoters.cfapps.io/api/random) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://creativecommons.org/licenses/by-nd/3.0/ with 1 occurrences migrated to:  
  https://creativecommons.org/licenses/by-nd/3.0/ ([https](https://creativecommons.org/licenses/by-nd/3.0/) result 200).
* [ ] http://docs.spring.io/spring-boot/docs/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/ ([https](https://docs.spring.io/spring-boot/docs/) result 200).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/ ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/) result 301).